### PR TITLE
Implement Cam control and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Aspects of the scene have been adjusted to utilize many of the Synesthesia Shade
 Audio Reactive elements include movement based on the audio input's time. Bass Hits will affect shadows and the purple glow.
 
 Scene controls allow the user to adjust parameters within the scene like glow, intensity, vibrance, camera parameters, and more.
+See the included `Scene Controls.png` for an overview of available controls.
 
 Demo video: https://www.youtube.com/watch?v=3HpyvFEv1yg
 
@@ -13,7 +14,7 @@ License: WTFPL, Author: Kevin McIntosh (Visional), found: https://github.com/kma
 
 ------------------------------------------------------------------------------
 
-An abstract, blobby-looking field - rendered in the style of hot, glowing glass. It was produced using cheap low-budget psuedoscience.
+An abstract, blobby-looking field - rendered in the style of hot, glowing glass. It was produced using cheap low-budget pseudoscience.
 
 The surface was constructed with a spherized sinusoidal function, of sorts. I like it, because 
 it's very cheap to produce, mildly reminiscent of noise and allows a camera to pass through it 

--- a/visional_glassy_field.synScene/main.glsl
+++ b/visional_glassy_field.synScene/main.glsl
@@ -1,5 +1,8 @@
 #define FAR 50. // Far plane, or maximum distance.
 
+// Additional camera speed control provided via the "Cam" slider.
+uniform float Cam;
+
 // float objID = 0.; // Object ID
 
 float accum; // Used to create the glow, by accumulating values in the raymarching function.
@@ -220,7 +223,8 @@ vec4 renderMainImage() {
 	
 	// Camera Setup.
 // 	float minSpeed = abs(syn_Intensity); // minimum speed threshold
-    float speed =  .75;
+    // Base speed multiplied by the "Cam" control for user adjustment.
+    float speed =  .75 * Cam;
     // max(minSpeed, abs((syn_Intensity) * abs(syn_BassPresence)));
     
     // speed = max(abs(speed*3), abs(minSpeed));


### PR DESCRIPTION
## Summary
- add a `Cam` uniform to control camera speed
- scale camera motion by Cam to enable the slider
- fix spelling of `pseudoscience` in README
- mention Scene Controls image in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684077f5b4a8832db5f4a658ca40e8ac